### PR TITLE
Anthony/xchaintx

### DIFF
--- a/primary-network/src/anthony/testing/.env
+++ b/primary-network/src/anthony/testing/.env
@@ -1,0 +1,16 @@
+# NEVER commit this file to version control!
+
+# RPC endpoints
+RPC_URL=https://api.avax-test.network/ext/bc/C/rpc
+MAINNET_RPC_URL=https://api.avax.network/ext/bc/C/rpc
+NODE_RPC_URL=http://3.132.173.83:9650/ext/
+
+# Wallet Info
+PRIVATE_KEY=0x02bc58ec8b7dd6d5b19201b97d29e4941ffa98d046745460fd62c0ac4bc84beb
+FROM_ADDRESS=0xBe14359Ac10597f6FeceEb12567c1DC26759c26f
+
+# Gas settings
+GAS_PRICE=25000000000
+
+# Other settings
+NETWORK=fuji

--- a/primary-network/src/primaryNetworkCoreClient.ts
+++ b/primary-network/src/primaryNetworkCoreClient.ts
@@ -1,4 +1,4 @@
-import { Context as ContextType, pvm, evm }  from '@avalabs/avalanchejs';
+import { Context as ContextType, pvm, evm, avm }  from '@avalabs/avalanchejs';
 import { Wallet } from "./wallet";
 import { getNodeUrlFromChain } from './utils';
 
@@ -8,6 +8,7 @@ export class PrimaryNetworkCore {
     context: ContextType.Context | undefined;
     pvmRpc: pvm.PVMApi;
     evmRpc: evm.EVMApi;
+    avmRpc: avm.AVMApi;
 
     constructor(params: {
         nodeUrl: `http${'s' | ''}://${string}`,
@@ -17,6 +18,7 @@ export class PrimaryNetworkCore {
         this.wallet = params.wallet
         this.pvmRpc = new pvm.PVMApi(this.nodeUrl)
         this.evmRpc = new evm.EVMApi(this.nodeUrl)
+        this.avmRpc = new avm.AVMApi(this.nodeUrl)
     }
 
     /**

--- a/primary-network/src/transactions/common/transaction.ts
+++ b/primary-network/src/transactions/common/transaction.ts
@@ -1,4 +1,4 @@
-import { type Common, type evm, utils, addTxSignatures, type pvm } from "@avalabs/avalanchejs";
+import { type Common, type avm, type evm, utils, addTxSignatures, type pvm } from "@avalabs/avalanchejs";
 import { sha256 } from "@noble/hashes/sha2";
 import type { Wallet } from "../../wallet";
 import type { NewTxParams } from "./types";
@@ -7,7 +7,7 @@ export class Transaction {
     unsignedTx: Common.UnsignedTx;
     tx: Common.Transaction
     nodeUrl: string;
-    rpc: pvm.PVMApi | evm.EVMApi;
+    rpc: pvm.PVMApi | evm.EVMApi | avm.AVMApi;
     wallet: Wallet | undefined;
 
     constructor(params: NewTxParams) {

--- a/primary-network/src/transactions/common/types.ts
+++ b/primary-network/src/transactions/common/types.ts
@@ -1,4 +1,4 @@
-import type { Common, Id, pvm, pvmSerial, TransferOutput, TypeSymbols, Utxo, evm }  from '@avalabs/avalanchejs';
+import type { Common, Id, pvm, pvmSerial, TransferOutput, TypeSymbols, Utxo, evm, avm }  from '@avalabs/avalanchejs';
 import type { Wallet } from '../../wallet';
 
 export type Output = {
@@ -65,11 +65,20 @@ export type FormattedCommonTxParams = {
     minIssuanceTime?: bigint;
 }
 
+export type FormattedCommonAvmTxParams = {
+    txFee: avm.TxFee;
+    fromAddressesBytes: Uint8Array[];
+    changeAddressesBytes?: Uint8Array[];
+    utxoSet: Utxo[];
+    memo?: Uint8Array;
+    minIssuanceTime?: bigint;
+}
+
 export type NewTxParams = {
     unsignedTx: Common.UnsignedTx,
     wallet: Wallet | undefined,
     nodeUrl: string,
-    rpc: pvm.PVMApi | evm.EVMApi
+    rpc: pvm.PVMApi | evm.EVMApi | avm.AVMApi
 }
 
 export type PChainOwner = {

--- a/primary-network/src/transactions/common/utils.ts
+++ b/primary-network/src/transactions/common/utils.ts
@@ -40,7 +40,7 @@ export function formatOutput(output: Output, context: ContextType.Context) {
     )
 }
 
-// temporary function for avm tx params with only necessary outputs for 
+// Provide Avm tx params with only necessary outputs for 
 // @GitHub/avalanche-sdk-typescript/primary-network/src/transactions/x-chain/transactions/exportTx.ts
 export async function fetchCommonAvmTxParams(
     txParams: CommonTxParams,

--- a/primary-network/src/transactions/fixtures/accounts.ts
+++ b/primary-network/src/transactions/fixtures/accounts.ts
@@ -1,33 +1,44 @@
 import { Address } from "@avalabs/avalanchejs";
 
 export const pAddressForTest = 'P-fuji19fc97zn3mzmwr827j4d3n45refkksgms4y2yzz'
+export const xAddressForTest = 'X-fuji19fc97zn3mzmwr827j4d3n45refkksgms4y2yzz'
 export const publicKeyForTest = '0x0245ae25e2903178ddc15a26bbaa05dc3c923aba8fb64d2443ea02d91589a22208'
 export const privateKeyForTest = '0x67d127b32d4c3dccba8a4493c9d6506e6e1c7e0f08fd45aace29c9973c7fc2ce'
 export const testOwnerPAddress = Address.fromString(pAddressForTest);
 
 export const pAddressForTest2 = 'P-fuji1pq96td5wmyjsgzl0vrcpk45p86p5ksh76hr7vk'
+export const xAddressForTest2 = 'X-fuji1pq96td5wmyjsgzl0vrcpk45p86p5ksh76hr7vk'
 export const publicKeyForTest2 = '0x03c75452cd6069adb6775f51a9169c3d2f074157028970a72621165f92f586bb65'
 export const privateKeyForTest2 = '0x9c31046749e2f8f9815b278023b0efb3d7561e1919c9afa9a088376f4cbe577c'
 export const testOwnerPAddress2 = Address.fromString(pAddressForTest2);
 
 export const pAddressForTest3 = 'P-fuji1jvvg09q06rhkzte25shumjz4vszm0em84hetzn'
+export const xAddressForTest3 = 'X-fuji1jvvg09q06rhkzte25shumjz4vszm0em84hetzn'
 export const publicKeyForTest3 = '0x02a1a17c6e06e24a65e4d7d596bbfb8333220abde9ab2c70d6ba4465d87f720e11'
 export const privateKeyForTest3 = '0x27fb5ca2bb6289b517da89cc4f762ea24767d86735d65f93932f88680d18c5cb'
 export const testOwnerPAddress3 = Address.fromString(pAddressForTest3);
 
 export const pAddressForTest4 = 'P-fuji12v456enlxznlwrvq3favqt0t2zawk28u80y23n'
+export const xAddressForTest4 = 'X-fuji12v456enlxznlwrvq3favqt0t2zawk28u80y23n'
 export const publicKeyForTest4 = '0x025004c8cafdc4c0c125292cc392b556a8efc4cbf386c60e8c151f8fd9975995d2'
 export const privateKeyForTest4 = '0x7a06c9a812887da2a8eef298ab95f5b4d3a7301d192a924e349a9d300ed8f9f0'
 export const testOwnerPAddress4 = Address.fromString(pAddressForTest4);
 
-export type TestAccount = {
+export type PChainTestAccount = {
     pAddress: string,
     privateKey: string,
     address: Address,
     publicKey: string,
 }
 
-export const accounts: TestAccount[] = [
+export type XChainTestAccount = {
+    xAddress: string,
+    privateKey: string,
+    address: Address,
+    publicKey: string,
+}
+
+export const PChainAccounts: PChainTestAccount[] = [
     {
         pAddress: pAddressForTest,
         privateKey: privateKeyForTest,
@@ -48,6 +59,33 @@ export const accounts: TestAccount[] = [
     },
     {
         pAddress: pAddressForTest4,
+        privateKey: privateKeyForTest4,
+        address: testOwnerPAddress4,
+        publicKey: publicKeyForTest4,
+    },
+]
+
+export const XChainAccounts: XChainTestAccount[] = [
+    {
+        xAddress: xAddressForTest,
+        privateKey: privateKeyForTest,
+        address: testOwnerPAddress,
+        publicKey: publicKeyForTest,
+    },
+    {
+        xAddress: xAddressForTest2,
+        privateKey: privateKeyForTest2,
+        address: testOwnerPAddress2,
+        publicKey: publicKeyForTest2,
+    },
+    {
+        xAddress: xAddressForTest3,
+        privateKey: privateKeyForTest3,
+        address: testOwnerPAddress3,
+        publicKey: publicKeyForTest3,
+    },
+    {
+        xAddress: xAddressForTest4,
         privateKey: privateKeyForTest4,
         address: testOwnerPAddress4,
         publicKey: publicKeyForTest4,

--- a/primary-network/src/transactions/fixtures/utils.ts
+++ b/primary-network/src/transactions/fixtures/utils.ts
@@ -5,10 +5,11 @@ import { utils } from "@avalabs/avalanchejs"
 export function checkOutputs(expectedOutputs: Output[], actualOutputs: (TransferableOutputFull | StakeableOutputFull)[]) {
     expect(actualOutputs.length, 'expected and actual outputs length mismatch').toBe(expectedOutputs.length)
     expectedOutputs.forEach((expected, index) => {
+        console.log("expected", expected.amount)
         const actual = actualOutputs[index]?.output
 
         // check amount
-        expect(actual?.amount().valueOf(), `output amount did not match for index ${index}`).toBe(BigInt(expected.amount * 1e9))
+        expect(actual?.amount().valueOf(), `output amount did not match for index ${index}`).toBe(BigInt(Math.round(expected.amount * 1e9)))
 
         // check owners
         const expectedOwners = expected.addresses.map(address => address.replace(/^[PX]-/, ''))

--- a/primary-network/src/transactions/fixtures/utils.ts
+++ b/primary-network/src/transactions/fixtures/utils.ts
@@ -11,7 +11,7 @@ export function checkOutputs(expectedOutputs: Output[], actualOutputs: (Transfer
         expect(actual?.amount().valueOf(), `output amount did not match for index ${index}`).toBe(BigInt(expected.amount * 1e9))
 
         // check owners
-        const expectedOwners = expected.addresses.map(address => address.replace('P-', ''))
+        const expectedOwners = expected.addresses.map(address => address.replace(/^[PX]-/, ''))
         let actualOwners: string[] = []
         if (actual) {
             if (utils.isTransferOut(actual)) {

--- a/primary-network/src/transactions/p-chain/txs/exportTx.test.ts
+++ b/primary-network/src/transactions/p-chain/txs/exportTx.test.ts
@@ -71,6 +71,10 @@ describe('exportTx', () => {
             addresses: changeAddresses,
         })
 
+        console.log("attention")
+        console.log(outputs)
+
+
         // check outputs
         checkOutputs(testOutputs, outputs)
 

--- a/primary-network/src/transactions/p-chain/txs/exportTx.test.ts
+++ b/primary-network/src/transactions/p-chain/txs/exportTx.test.ts
@@ -71,10 +71,6 @@ describe('exportTx', () => {
             addresses: changeAddresses,
         })
 
-        console.log("attention")
-        console.log(outputs)
-
-
         // check outputs
         checkOutputs(testOutputs, outputs)
 

--- a/primary-network/src/transactions/x-chain/common/transaction.ts
+++ b/primary-network/src/transactions/x-chain/common/transaction.ts
@@ -1,0 +1,10 @@
+import { Transaction as CommonTransaction } from "../../common/transaction";
+import { toTransferableOutput } from "../../common/utils";
+import type { avmSerial } from "@avalabs/avalanchejs";
+
+export class Transaction extends CommonTransaction {
+    getOutputs() {
+        const transferableOutputs = (this.tx as avmSerial.BaseTx).baseTx.outputs
+        return transferableOutputs.map(toTransferableOutput)
+    }
+}

--- a/primary-network/src/transactions/x-chain/transactions/baseTx.test.ts
+++ b/primary-network/src/transactions/x-chain/transactions/baseTx.test.ts
@@ -149,12 +149,7 @@ describe('newBaseTx', () => {
         const outputs = result.getOutputs()
 
         const fee = (await mockAvmRpc.getTxFee()).txFee
-        // // Use integer arithmetic in nanoAvax to avoid precision issues
-        // const testSpentAmountNano = avaxToNanoAvax(testSpentAmount)
-        // const testOutputAmountNano = avaxToNanoAvax(testOutputAmount)
-        // const expectedChangeAmountNano = testSpentAmountNano - testOutputAmountNano - fee
         const expectedChangeAmount = testSpentAmount - testOutputAmount - (Number(fee) / 1e9)
-        // const expectedChangeAmount = nanoAvaxToAvax(expectedChangeAmountNano)
 
         // expected change output
         testOutputs.push({

--- a/primary-network/src/transactions/x-chain/transactions/baseTx.test.ts
+++ b/primary-network/src/transactions/x-chain/transactions/baseTx.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it, vi, type Mock, beforeEach } from 'vitest';
+import { avm, utils } from '@avalabs/avalanchejs';
+import { newBaseTx } from './baseTx';
+import type { PrimaryNetworkCore } from '../../../primaryNetworkCoreClient';
+import type { BaseTxParams } from './baseTx';
+import { feeState, testContext, getValidUtxo } from '../../fixtures/transactions';
+import { xAddressForTest, xAddressForTest2, xAddressForTest3, xAddressForTest4, privateKeyForTest, privateKeyForTest2 } from '../../fixtures/accounts';
+import type { Output } from '../../common/types';
+import { checkOutputs } from '../../fixtures/utils';
+import { avaxToNanoAvax, getChainIdFromAlias, nanoAvaxToAvax } from '../../common/utils';
+
+describe('newBaseTx', () => {
+    const testInputAmount = 1
+    
+    // mocked wallet always returns 1 avax utxo
+    const mockWallet = {
+        getBech32Addresses: vi.fn().mockReturnValue([xAddressForTest]),
+        getPrivateKeysBuffer: vi.fn().mockReturnValue([utils.hexToBuffer(privateKeyForTest)]),
+        getUtxos: vi.fn().mockResolvedValue([getValidUtxo(testInputAmount /* avax */)]),
+    };
+
+    const mockAvmRpc = {
+        getFeeState: vi.fn().mockResolvedValue(feeState()),
+        getTxFee: vi.fn().mockResolvedValue({ txFee: testContext.baseTxFee, createAssetTxFee: testContext.createAssetTxFee }),
+    };
+    
+    const mockPrimaryNetworkCoreClient = {
+        initializeContextIfNot: vi.fn().mockResolvedValue(testContext),
+        avmRpc: mockAvmRpc,
+        wallet: mockWallet,
+        nodeUrl: 'http://localhost:9650',
+    } as unknown as PrimaryNetworkCore;
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        // Reset mock implementation to default
+        mockWallet.getUtxos = vi.fn().mockResolvedValue([getValidUtxo(testInputAmount /* avax */)])
+    });
+
+    it('should create correct outputs and fees', async () => {
+        const receiverAddresses = [xAddressForTest, xAddressForTest3]
+        const changeAddresses = [xAddressForTest2]
+
+        const testOutputAmount = 0.1234
+        const testOutputs: Output[] = [{
+            amount: testOutputAmount,
+            addresses: receiverAddresses,
+        }]
+        const mockTxParams: BaseTxParams = {
+            changeAddresses: changeAddresses,
+            outputs: testOutputs
+        };
+
+        const result = await newBaseTx(mockPrimaryNetworkCoreClient, mockTxParams);
+        const outputs = result.getOutputs()
+
+        // Calculate fees using X-chain pattern
+        const fee = (await mockAvmRpc.getTxFee()).txFee
+        const expectedFeesInAvax = Number(fee) / 1e9
+        const expectedChangeAmount = testInputAmount - testOutputAmount - expectedFeesInAvax
+
+        // expected change output
+        testOutputs.push({
+            amount: expectedChangeAmount,
+            addresses: changeAddresses,
+        })
+
+        // theres must be 2 outputs
+        expect(outputs.length, 'expected and actual outputs length mismatch').toBe(2)
+
+        // check outputs
+        checkOutputs(testOutputs, outputs)
+
+        // actual burned amount is same as fees
+        const allInputAmounts = result.tx.getInputs().reduce((acc, i) => acc + i.amount(), 0n)
+        const allOutputAmounts = result.tx.baseTx.outputs.reduce((acc, i) => acc + i.amount(), 0n)
+        expect(allInputAmounts - allOutputAmounts, 'expected and actual burned amount mismatch').toBe(BigInt(expectedFeesInAvax * 1e9))
+    });
+
+    it('should only use utxos passed in params', async () => {
+        const receiverAddresses = [xAddressForTest, xAddressForTest3]
+        const changeAddresses = [xAddressForTest2]
+
+        const testOutputAmount = 0.1234
+        const testInputAmount = 0.5
+        const testOutputs = [{
+            amount: testOutputAmount,
+            addresses: receiverAddresses,
+        }];
+        const mockTxParams: BaseTxParams = {
+            changeAddresses: changeAddresses,
+            // utxos passed here override the wallet's or fromAddresses' utxos
+            utxos: [getValidUtxo(testInputAmount /* avax */)],
+            outputs: testOutputs
+        };
+
+        const result = await newBaseTx(mockPrimaryNetworkCoreClient, mockTxParams);
+        const outputs = result.getOutputs()
+
+        // calculate fees using X-chain pattern
+        const fee = (await mockAvmRpc.getTxFee()).txFee
+        const expectedFeesInAvax = Number(fee) / 1e9
+        // if utxos passed in params are only used, then testInputAmount will be 0.5 instead of default 1
+        const expectedChangeAmount = testInputAmount - testOutputAmount - expectedFeesInAvax
+
+        // expected change output
+        testOutputs.push({
+            amount: expectedChangeAmount,
+            addresses: changeAddresses,
+        })
+
+        // theres must be 2 outputs
+        expect(outputs.length, 'expected and actual outputs length mismatch').toBe(2)
+
+        // match testOutputs with outputs
+        checkOutputs(testOutputs, outputs)
+
+        // actual burned amount is same as fees
+        const allInputAmounts = result.tx.getInputs().reduce((acc, i) => acc + i.amount(), 0n)
+        const allOutputAmounts = result.tx.baseTx.outputs.reduce((acc, i) => acc + i.amount(), 0n)
+        expect(allInputAmounts - allOutputAmounts).toBe(BigInt(expectedFeesInAvax * 1e9))
+    });
+
+    it('should use `fromAddresses` for fetching utxos and change addresses', async () => {
+        const testSpentAmount = 0.645
+        const spenderAddresses = [xAddressForTest4]
+        const receiverAddresses = [xAddressForTest, xAddressForTest3]
+
+        mockWallet.getUtxos = vi.fn().mockImplementation((addresses: string[]) => {
+            if (addresses.includes(xAddressForTest4)) {
+                return [getValidUtxo(testSpentAmount /* avax */, undefined, spenderAddresses)];
+            }
+            // if test spender address is not used, the mock will return empty utxos array
+            // and tx won't be built
+            return [];
+        })
+
+        const testOutputAmount = 0.1234
+        const testOutputs: Output[] = [{
+            amount: testOutputAmount,
+            addresses: receiverAddresses,
+        }]
+        const mockTxParams: BaseTxParams = {
+            fromAddresses: spenderAddresses,
+            outputs: testOutputs
+        };
+
+        const result = await newBaseTx(mockPrimaryNetworkCoreClient, mockTxParams);
+        const outputs = result.getOutputs()
+
+        const fee = (await mockAvmRpc.getTxFee()).txFee
+        // // Use integer arithmetic in nanoAvax to avoid precision issues
+        // const testSpentAmountNano = avaxToNanoAvax(testSpentAmount)
+        // const testOutputAmountNano = avaxToNanoAvax(testOutputAmount)
+        // const expectedChangeAmountNano = testSpentAmountNano - testOutputAmountNano - fee
+        const expectedChangeAmount = testSpentAmount - testOutputAmount - (Number(fee) / 1e9)
+        // const expectedChangeAmount = nanoAvaxToAvax(expectedChangeAmountNano)
+
+        // expected change output
+        testOutputs.push({
+            amount: expectedChangeAmount,
+            // this will test if change address is not passed,
+            // then fromAddresses will be used.
+            addresses: spenderAddresses,
+        })
+
+        // theres must be 2 outputs
+        expect(outputs.length, 'expected and actual outputs length mismatch').toBe(2)
+
+        // check outputs
+        checkOutputs(testOutputs, outputs)
+
+        // actual burned amount is same as fees
+        const allInputAmounts = result.tx.getInputs().reduce((acc, i) => acc + i.amount(), 0n)
+        const allOutputAmounts = result.tx.baseTx.outputs.reduce((acc, i) => acc + i.amount(), 0n)
+        expect(allInputAmounts - allOutputAmounts, 'expected and actual burned amount mismatch').toBe(fee)
+    })
+
+    it('should sign the tx properly', async () => {
+        const receiverAddresses = [xAddressForTest, xAddressForTest3]
+        const changeAddresses = [xAddressForTest2]
+
+        const testOutputAmount = 0.1234
+        const testOutputs: Output[] = [{
+            amount: testOutputAmount,
+            addresses: receiverAddresses,
+        }]
+        const mockTxParams: BaseTxParams = {
+            changeAddresses: changeAddresses,
+            outputs: testOutputs
+        };
+
+        const result = await newBaseTx(mockPrimaryNetworkCoreClient, mockTxParams);
+        await result.sign()
+        expect(result.unsignedTx.hasAllSignatures(), 'tx did not have all signatures').toBe(true)
+    });
+
+    it('should sign the multi sig tx properly', async () => {
+        // the wallet will return a single multi-sig utxo, with one address already in the wallet.
+        // another signature will be added directly 
+        mockWallet.getUtxos = vi.fn().mockImplementation(() => [
+            getValidUtxo(1 /* avax */, undefined, [xAddressForTest, xAddressForTest2], undefined, 2),
+        ])
+        const receiverAddresses = [xAddressForTest3]
+        const changeAddresses = [xAddressForTest4]
+
+        const testOutputAmount = 0.1234
+        const testOutputs: Output[] = [{
+            amount: testOutputAmount,
+            addresses: receiverAddresses,
+        }]
+        const mockTxParams: BaseTxParams = {
+            fromAddresses: [xAddressForTest, xAddressForTest2],
+            changeAddresses: changeAddresses,
+            outputs: testOutputs
+        };
+
+        const result = await newBaseTx(mockPrimaryNetworkCoreClient, mockTxParams);
+        await result.sign() // signed with wallet
+        expect(result.unsignedTx.hasAllSignatures(), 'tx have all signatures for the multi-sig without signing').toBe(false)
+        await result.sign([privateKeyForTest2]) // signed by directly passing private key
+        expect(result.unsignedTx.hasAllSignatures(), 'tx did not have all signatures').toBe(true)
+    });
+
+    it('should give correct tx hash', async () => {
+        const receiverAddresses = [xAddressForTest, xAddressForTest3]
+        const changeAddresses = [xAddressForTest2]
+
+        const testOutputAmount = 0.1234
+        const testOutputs: Output[] = [{
+            amount: testOutputAmount,
+            addresses: receiverAddresses,
+        }]
+        const mockTxParams: BaseTxParams = {
+            changeAddresses: changeAddresses,
+            outputs: testOutputs
+        };
+
+        const result = await newBaseTx(mockPrimaryNetworkCoreClient, mockTxParams);
+        await result.sign()
+        expect(result.getId(), 'expected and actual tx hash mismatch').toBe('2dj5QDTEi6G6vPuVdY3LBbFWgffKes8GurLbUxGeCypvHLZzHP')
+    })
+
+    it('should handle errors appropriately', async () => {
+        const mockTxParams: BaseTxParams = {
+            fromAddresses: [xAddressForTest],
+            outputs: [{
+                amount: 40,
+                addresses: [xAddressForTest],
+            }],
+        };
+
+        // Mock an error in initializeContextIfNot
+        (mockPrimaryNetworkCoreClient.initializeContextIfNot as Mock).mockRejectedValue(
+            new Error('Failed to initialize context')
+        );
+
+        // Verify that the error is propagated
+        await expect(
+            newBaseTx(mockPrimaryNetworkCoreClient, mockTxParams)
+        ).rejects.toThrow('Failed to initialize context');
+    });
+}); 

--- a/primary-network/src/transactions/x-chain/transactions/baseTx.ts
+++ b/primary-network/src/transactions/x-chain/transactions/baseTx.ts
@@ -1,0 +1,58 @@
+import { avm, type avmSerial } from "@avalabs/avalanchejs";
+import { Transaction } from "../common/transaction";
+import { fetchCommonAvmTxParams, formatOutput } from "../../common/utils";
+import type { CommonTxParams, NewTxParams, Output } from "../../common/types";
+import type { PrimaryNetworkCore } from "../../../primaryNetworkCoreClient";
+
+export type BaseTxParams = CommonTxParams & {
+    /**
+     * Optional. Outputs to send funds to. It can
+     * be used to specify resulting UTXOs.
+     */
+    outputs?: Output[],
+}
+
+export class BaseTx extends Transaction {
+    override tx: avmSerial.BaseTx;
+
+    constructor(params: NewTxParams) {
+        super(params)
+        this.tx = params.unsignedTx.getTx() as avmSerial.BaseTx
+    }
+}
+
+export async function newBaseTx(
+    primaryNetworkCoreClient: PrimaryNetworkCore,
+    txParams: BaseTxParams,
+): Promise<BaseTx> {
+    const context = await primaryNetworkCoreClient.initializeContextIfNot()
+
+    // Format outputs as per AvalancheJS
+    const formattedOutputs = txParams.outputs ? txParams.outputs.map(output => formatOutput(output, context)) : []
+
+    const { commonTxParams } = await fetchCommonAvmTxParams(
+        txParams,
+        context,
+        primaryNetworkCoreClient.avmRpc,
+        primaryNetworkCoreClient.wallet,
+    )
+
+    const unsignedTx = avm.newBaseTx(
+        context,
+        commonTxParams.fromAddressesBytes,
+        commonTxParams.utxoSet,
+        formattedOutputs,
+        {
+            ...(commonTxParams.changeAddressesBytes && { changeAddresses: commonTxParams.changeAddressesBytes }),
+            ...(commonTxParams.minIssuanceTime && { minIssuanceTime: commonTxParams.minIssuanceTime }),
+            ...(commonTxParams.memo && { memo: commonTxParams.memo }),
+        },
+    );
+
+    return new BaseTx({
+        unsignedTx,
+        wallet: primaryNetworkCoreClient.wallet,
+        nodeUrl: primaryNetworkCoreClient.nodeUrl,
+        rpc: primaryNetworkCoreClient.avmRpc,
+    })
+}

--- a/primary-network/src/transactions/x-chain/transactions/exportTx.test.ts
+++ b/primary-network/src/transactions/x-chain/transactions/exportTx.test.ts
@@ -7,6 +7,7 @@ import { xAddressForTest, xAddressForTest2, xAddressForTest3, xAddressForTest4, 
 import type { Output } from '../../common/types';
 import { checkOutputs } from '../../fixtures/utils';
 import { avaxToNanoAvax, getChainIdFromAlias, nanoAvaxToAvax } from '../../common/utils';
+import { mock } from 'node:test';
 
 describe('exportTx', () => {
     const testInputAmount = 1
@@ -20,11 +21,12 @@ describe('exportTx', () => {
 
     const mockAvmRpc = {
         getFeeState: vi.fn().mockResolvedValue(feeState()),
+        getTxFee: vi.fn().mockResolvedValue({ txFee: testContext.baseTxFee, createAssetTxFee: testContext.createAssetTxFee }),
     };
     
     const mockPrimaryNetworkCoreClient = {
         initializeContextIfNot: vi.fn().mockResolvedValue(testContext),
-        AvmRpc: mockAvmRpc,
+        avmRpc: mockAvmRpc,
         wallet: mockWallet,
         nodeUrl: 'http://localhost:9650',
     } as unknown as PrimaryNetworkCore;
@@ -62,7 +64,7 @@ describe('exportTx', () => {
         const outputs = result.getExportedOutputs()
         outputs.push(...result.getOutputs())
 
-        const fee = (await avm.getTxFee()).txFee
+        const fee = (await mockAvmRpc.getTxFee()).txFee
         const expectedChangeAmount = avaxToNanoAvax(testInputAmount) - avaxToNanoAvax(testOutputAmount) - avaxToNanoAvax(testOutputAmount2) - fee
 
         // expected change output
@@ -81,8 +83,8 @@ describe('exportTx', () => {
     });
 
     it('should create correct export tx details', async () => {
-        const receiverAddresses = [pAddressForTest, pAddressForTest3]
-        const changeAddresses = [pAddressForTest2]
+        const receiverAddresses = [xAddressForTest, xAddressForTest3]
+        const changeAddresses = [xAddressForTest2]
 
         const testOutputAmount = 0.1234
         const testOutputs: Output[] = [{
@@ -115,8 +117,8 @@ describe('exportTx', () => {
     });
 
     it('should create correct tx hash', async () => {
-        const receiverAddresses = [pAddressForTest, pAddressForTest3]
-        const changeAddresses = [pAddressForTest2]
+        const receiverAddresses = [xAddressForTest, xAddressForTest3]
+        const changeAddresses = [xAddressForTest2]
 
         const testOutputAmount = 0.1234
         const testOutputs: Output[] = [{
@@ -142,11 +144,11 @@ describe('exportTx', () => {
         expect(
             cChainExportTx.getId(),
             'expected c-chain export tx hash mismatch',
-        ).toBe('29d94GvoD5dLnZUuLD5uv8HaKwwGNGCrpGWtGR7ZbwrtwzaaHp')
+        ).toBe('2oy8wE7wXtDhmEwW61RyEp2BjN66ZnvAWZKZWeENWheyacdgQp')
 
         expect(
             pChainExportTx.getId(),
             'expected p-chain export tx hash mismatch',
-        ).toBe('297fxqPXUbThB9EqDVVvXhE5bNYifpnqhXvMPtZsk9vTtA7Lg9')
+        ).toBe('2BJxkJ4mbf1Pwvm6m4KaVUU73NvNX5gzdUZ8kRcvpBM1AHzBN2')
     });
 }); 

--- a/primary-network/src/transactions/x-chain/transactions/exportTx.test.ts
+++ b/primary-network/src/transactions/x-chain/transactions/exportTx.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { avm, pvm, utils } from '@avalabs/avalanchejs';
+import { type ExportTxParams, newExportTx } from './exportTx';
+import type { PrimaryNetworkCore } from '../../../primaryNetworkCoreClient';
+import { feeState, testContext, getValidUtxo } from '../../fixtures/transactions';
+import { pAddressForTest, pAddressForTest2, pAddressForTest3, pAddressForTest4, privateKeyForTest } from '../../fixtures/accounts';
+import type { Output } from '../../common/types';
+import { checkOutputs } from '../../fixtures/utils';
+import { avaxToNanoAvax, getChainIdFromAlias, nanoAvaxToAvax } from '../../common/utils';
+
+describe('exportTx', () => {
+    const testInputAmount = 1
+    
+    // mocked wallet always returns 1 avax utxo
+    const mockWallet = {
+        getBech32Addresses: vi.fn().mockReturnValue([pAddressForTest]),
+        getPrivateKeysBuffer: vi.fn().mockReturnValue([utils.hexToBuffer(privateKeyForTest)]),
+        getUtxos: vi.fn().mockResolvedValue([getValidUtxo(testInputAmount /* avax */)]),
+    };
+
+    const mockAvmRpc = {
+        getFeeState: vi.fn().mockResolvedValue(feeState()),
+    };
+    
+    const mockPrimaryNetworkCoreClient = {
+        initializeContextIfNot: vi.fn().mockResolvedValue(testContext),
+        AvmRpc: mockAvmRpc,
+        wallet: mockWallet,
+        nodeUrl: 'http://localhost:9650',
+    } as unknown as PrimaryNetworkCore;
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        // Reset mock implementation to default
+        mockWallet.getUtxos = vi.fn().mockResolvedValue([getValidUtxo(testInputAmount /* avax */)])
+    });
+
+    it('should create correct outputs and fees', async () => {
+        const receiverAddresses = [pAddressForTest, pAddressForTest3]
+        const receiverAddresses2 = [pAddressForTest4]
+        const changeAddresses = [pAddressForTest2]
+
+        const testOutputAmount = 0.1234
+        const testOutputAmount2 = 0.2345
+        const testOutputs: Output[] = [
+            {
+                amount: testOutputAmount,
+                addresses: receiverAddresses,
+            },
+            {
+                amount: testOutputAmount2,
+                addresses: receiverAddresses2,
+            },
+        ]
+        const mockTxParams: ExportTxParams = {
+            changeAddresses: changeAddresses,
+            exportedOutputs: testOutputs,
+            destinationChain: 'C'
+        };
+
+        const result = await newExportTx(mockPrimaryNetworkCoreClient, mockTxParams);
+        const outputs = result.getExportedOutputs()
+        outputs.push(...result.getOutputs())
+
+        const fee = avm.calculateFee(result.tx, testContext.platformFeeConfig.weights, feeState().price)
+        const expectedChangeAmount = avaxToNanoAvax(testInputAmount) - avaxToNanoAvax(testOutputAmount) - avaxToNanoAvax(testOutputAmount2) - fee
+
+        // expected change output
+        testOutputs.push({
+            amount: nanoAvaxToAvax(expectedChangeAmount),
+            addresses: changeAddresses,
+        })
+
+        // check outputs
+        checkOutputs(testOutputs, outputs)
+
+        // actual burned amount is same as fees
+        const allInputAmounts = result.tx.getInputs().reduce((acc, i) => acc + i.amount(), 0n)
+        const allOutputAmounts = outputs.reduce((acc, i) => acc + i.output.amount(), 0n)
+        expect(allInputAmounts - allOutputAmounts, 'expected and actual burned amount mismatch').toBe(fee)
+    });
+
+    it('should create correct export tx details', async () => {
+        const receiverAddresses = [pAddressForTest, pAddressForTest3]
+        const changeAddresses = [pAddressForTest2]
+
+        const testOutputAmount = 0.1234
+        const testOutputs: Output[] = [{
+            amount: testOutputAmount,
+            addresses: receiverAddresses,
+        }]
+        const mockTxParamsCChain: ExportTxParams = {
+            changeAddresses: changeAddresses,
+            exportedOutputs: testOutputs,
+            destinationChain: 'C'
+        };
+        const cChainExportTx = await newExportTx(mockPrimaryNetworkCoreClient, mockTxParamsCChain);
+
+        const mockTxParamsPChain: ExportTxParams = {
+            changeAddresses: changeAddresses,
+            exportedOutputs: testOutputs,
+            destinationChain: 'P'
+        };
+        const pChainExportTx = await newExportTx(mockPrimaryNetworkCoreClient, mockTxParamsPChain);
+
+        expect(
+            cChainExportTx.tx.destination.value(),
+            'expected destination chain mismatch for c-chain export tx',
+        ).toBe(getChainIdFromAlias(mockTxParamsCChain.destinationChain, testContext.networkID))
+
+        expect(
+            pChainExportTx.tx.destination.value(),
+            'expected destination chain mismatch for x-chain export tx',
+        ).toBe(getChainIdFromAlias(mockTxParamsPChain.destinationChain, testContext.networkID))
+    });
+
+    it('should create correct tx hash', async () => {
+        const receiverAddresses = [pAddressForTest, pAddressForTest3]
+        const changeAddresses = [pAddressForTest2]
+
+        const testOutputAmount = 0.1234
+        const testOutputs: Output[] = [{
+            amount: testOutputAmount,
+            addresses: receiverAddresses,
+        }]
+        const mockTxParamsCChain: ExportTxParams = {
+            changeAddresses: changeAddresses,
+            exportedOutputs: testOutputs,
+            destinationChain: 'C'
+        };
+        const cChainExportTx = await newExportTx(mockPrimaryNetworkCoreClient, mockTxParamsCChain);
+        await cChainExportTx.sign()
+
+        const mockTxParamsPChain: ExportTxParams = {
+            changeAddresses: changeAddresses,
+            exportedOutputs: testOutputs,
+            destinationChain: 'P'
+        };
+        const pChainExportTx = await newExportTx(mockPrimaryNetworkCoreClient, mockTxParamsPChain);
+        await pChainExportTx.sign()
+
+        expect(
+            cChainExportTx.getId(),
+            'expected c-chain export tx hash mismatch',
+        ).toBe('29d94GvoD5dLnZUuLD5uv8HaKwwGNGCrpGWtGR7ZbwrtwzaaHp')
+
+        expect(
+            pChainExportTx.getId(),
+            'expected p-chain export tx hash mismatch',
+        ).toBe('297fxqPXUbThB9EqDVVvXhE5bNYifpnqhXvMPtZsk9vTtA7Lg9')
+    });
+}); 

--- a/primary-network/src/transactions/x-chain/transactions/exportTx.test.ts
+++ b/primary-network/src/transactions/x-chain/transactions/exportTx.test.ts
@@ -3,7 +3,7 @@ import { avm, pvm, utils } from '@avalabs/avalanchejs';
 import { type ExportTxParams, newExportTx } from './exportTx';
 import type { PrimaryNetworkCore } from '../../../primaryNetworkCoreClient';
 import { feeState, testContext, getValidUtxo } from '../../fixtures/transactions';
-import { pAddressForTest, pAddressForTest2, pAddressForTest3, pAddressForTest4, privateKeyForTest } from '../../fixtures/accounts';
+import { xAddressForTest, xAddressForTest2, xAddressForTest3, xAddressForTest4, privateKeyForTest } from '../../fixtures/accounts';
 import type { Output } from '../../common/types';
 import { checkOutputs } from '../../fixtures/utils';
 import { avaxToNanoAvax, getChainIdFromAlias, nanoAvaxToAvax } from '../../common/utils';
@@ -13,7 +13,7 @@ describe('exportTx', () => {
     
     // mocked wallet always returns 1 avax utxo
     const mockWallet = {
-        getBech32Addresses: vi.fn().mockReturnValue([pAddressForTest]),
+        getBech32Addresses: vi.fn().mockReturnValue([xAddressForTest]),
         getPrivateKeysBuffer: vi.fn().mockReturnValue([utils.hexToBuffer(privateKeyForTest)]),
         getUtxos: vi.fn().mockResolvedValue([getValidUtxo(testInputAmount /* avax */)]),
     };
@@ -36,9 +36,9 @@ describe('exportTx', () => {
     });
 
     it('should create correct outputs and fees', async () => {
-        const receiverAddresses = [pAddressForTest, pAddressForTest3]
-        const receiverAddresses2 = [pAddressForTest4]
-        const changeAddresses = [pAddressForTest2]
+        const receiverAddresses = [xAddressForTest, xAddressForTest3]
+        const receiverAddresses2 = [xAddressForTest4]
+        const changeAddresses = [xAddressForTest2]
 
         const testOutputAmount = 0.1234
         const testOutputAmount2 = 0.2345
@@ -62,7 +62,7 @@ describe('exportTx', () => {
         const outputs = result.getExportedOutputs()
         outputs.push(...result.getOutputs())
 
-        const fee = avm.calculateFee(result.tx, testContext.platformFeeConfig.weights, feeState().price)
+        const fee = (await avm.getTxFee()).txFee
         const expectedChangeAmount = avaxToNanoAvax(testInputAmount) - avaxToNanoAvax(testOutputAmount) - avaxToNanoAvax(testOutputAmount2) - fee
 
         // expected change output

--- a/primary-network/src/transactions/x-chain/transactions/exportTx.ts
+++ b/primary-network/src/transactions/x-chain/transactions/exportTx.ts
@@ -16,7 +16,6 @@ export type ExportTxParams = CommonTxParams & {
      */
     exportedOutputs: Output[];
 }
-
 export class ExportTx extends Transaction {
     override tx: avmSerial.ExportTx;
 
@@ -42,14 +41,11 @@ export async function newExportTx(
     const exportedOutputs = txPrams.exportedOutputs.map(output => formatOutput(output, context))
 
     const unsignedTx = avm.newExportTx(
-        {
-            context, 
-            destinationChainId: getChainIdFromAlias(txPrams.destinationChain, context.networkID),
-            fromAddressesBytes: commonTxParams.fromAddressesBytes,
-            utxoSet: commonTxParams.utxoSet,
-            outputs: exportedOutputs,
-        },
-        context,
+        context, 
+        getChainIdFromAlias(txPrams.destinationChain, context.networkID),
+        commonTxParams.fromAddressesBytes,
+        commonTxParams.utxoSet,
+        exportedOutputs,
     );
 
     return new ExportTx({

--- a/primary-network/src/transactions/x-chain/transactions/exportTx.ts
+++ b/primary-network/src/transactions/x-chain/transactions/exportTx.ts
@@ -1,0 +1,62 @@
+import { avm, type avmSerial } from "@avalabs/avalanchejs";
+import { Transaction } from "../common/transaction";
+import { fetchCommonAvmTxParams, formatOutput, getChainIdFromAlias, toTransferableOutput } from "../../common/utils";
+import type { CommonTxParams, NewTxParams, Output } from "../../common/types";
+import type { P_CHAIN_ALIAS, C_CHAIN_ALIAS } from "../../common/consts";
+import type { PrimaryNetworkCore } from "../../../primaryNetworkCoreClient";
+
+
+export type ExportTxParams = CommonTxParams & {
+    /**
+     * The chain to export the funds to.
+     */
+    destinationChain: typeof P_CHAIN_ALIAS | typeof C_CHAIN_ALIAS;
+    /**
+     * The outputs to export.
+     */
+    exportedOutputs: Output[];
+}
+
+export class ExportTx extends Transaction {
+    override tx: avmSerial.ExportTx;
+
+    constructor(params: NewTxParams) {
+        super(params)
+        this.tx = params.unsignedTx.getTx() as avmSerial.ExportTx
+    }
+
+    getExportedOutputs() {
+        const transferableOutputs = this.tx.outs
+        return transferableOutputs.map(toTransferableOutput)
+    }
+}
+
+export async function newExportTx(
+    primaryNetworkCoreClient: PrimaryNetworkCore,
+    txPrams: ExportTxParams,
+): Promise<ExportTx> {
+    // added -avmRpc: avm.AVMApi- feild to primaryNetworkCoreClient
+    const context = await primaryNetworkCoreClient.initializeContextIfNot()
+    const { commonTxParams } = await fetchCommonAvmTxParams(txPrams, context, primaryNetworkCoreClient.avmRpc, primaryNetworkCoreClient.wallet)
+
+    const exportedOutputs = txPrams.exportedOutputs.map(output => formatOutput(output, context))
+
+    const unsignedTx = avm.newExportTx(
+        {
+            context, 
+            destinationChainId: getChainIdFromAlias(txPrams.destinationChain, context.networkID),
+            fromAddressesBytes: commonTxParams.fromAddressesBytes,
+            utxoSet: commonTxParams.utxoSet,
+            outputs: exportedOutputs,
+        },
+        context,
+    );
+
+    return new ExportTx({
+        unsignedTx,
+        rpc: primaryNetworkCoreClient.avmRpc,
+        nodeUrl: primaryNetworkCoreClient.nodeUrl,
+        wallet: primaryNetworkCoreClient.wallet,
+    })
+}
+

--- a/primary-network/src/transactions/x-chain/transactions/exportTx.ts
+++ b/primary-network/src/transactions/x-chain/transactions/exportTx.ts
@@ -32,17 +32,17 @@ export class ExportTx extends Transaction {
 
 export async function newExportTx(
     primaryNetworkCoreClient: PrimaryNetworkCore,
-    txPrams: ExportTxParams,
+    txParams: ExportTxParams,
 ): Promise<ExportTx> {
     // added -avmRpc: avm.AVMApi- feild to primaryNetworkCoreClient
     const context = await primaryNetworkCoreClient.initializeContextIfNot()
-    const { commonTxParams } = await fetchCommonAvmTxParams(txPrams, context, primaryNetworkCoreClient.avmRpc, primaryNetworkCoreClient.wallet)
+    const { commonTxParams } = await fetchCommonAvmTxParams(txParams, context, primaryNetworkCoreClient.avmRpc, primaryNetworkCoreClient.wallet)
 
-    const exportedOutputs = txPrams.exportedOutputs.map(output => formatOutput(output, context))
+    const exportedOutputs = txParams.exportedOutputs.map(output => formatOutput(output, context))
 
     const unsignedTx = avm.newExportTx(
         context, 
-        getChainIdFromAlias(txPrams.destinationChain, context.networkID),
+        getChainIdFromAlias(txParams.destinationChain, context.networkID),
         commonTxParams.fromAddressesBytes,
         commonTxParams.utxoSet,
         exportedOutputs,

--- a/primary-network/src/transactions/x-chain/transactions/exportTx.ts
+++ b/primary-network/src/transactions/x-chain/transactions/exportTx.ts
@@ -46,6 +46,11 @@ export async function newExportTx(
         commonTxParams.fromAddressesBytes,
         commonTxParams.utxoSet,
         exportedOutputs,
+        {
+            ...(commonTxParams.changeAddressesBytes && { changeAddresses: commonTxParams.changeAddressesBytes }),
+            ...(commonTxParams.minIssuanceTime && { minIssuanceTime: commonTxParams.minIssuanceTime }),
+            ...(commonTxParams.memo && { memo: commonTxParams.memo }),
+        },
     );
 
     return new ExportTx({

--- a/primary-network/src/transactions/x-chain/transactions/importTx.test.ts
+++ b/primary-network/src/transactions/x-chain/transactions/importTx.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { avm, utils } from '@avalabs/avalanchejs';
+import { type ImportedOutput, type ImportTxParams, newImportTx } from './importTx';
+import type { PrimaryNetworkCore } from '../../../primaryNetworkCoreClient';
+import { feeState, testContext, getValidUtxo } from '../../fixtures/transactions';
+import { xAddressForTest, xAddressForTest3, privateKeyForTest } from '../../fixtures/accounts';
+import type { Output } from '../../common/types';
+import { checkOutputs } from '../../fixtures/utils';
+import { avaxToNanoAvax, getChainIdFromAlias, nanoAvaxToAvax } from '../../common/utils';
+
+describe('importTx', () => {
+    const testInputAmount = 1
+    
+    // mocked wallet always returns 1 avax utxo
+    const mockWallet = {
+        getBech32Addresses: vi.fn().mockReturnValue([xAddressForTest]),
+        getPrivateKeysBuffer: vi.fn().mockReturnValue([utils.hexToBuffer(privateKeyForTest)]),
+        getUtxos: vi.fn().mockResolvedValue([getValidUtxo(testInputAmount /* avax */)]),
+    };
+
+    const mockAvmRpc = {
+        getFeeState: vi.fn().mockResolvedValue(feeState()),
+        getTxFee: vi.fn().mockResolvedValue({ txFee: testContext.baseTxFee, createAssetTxFee: testContext.createAssetTxFee }),
+    };
+    
+    const mockPrimaryNetworkCoreClient = {
+        initializeContextIfNot: vi.fn().mockResolvedValue(testContext),
+        avmRpc: mockAvmRpc,
+        wallet: mockWallet,
+        nodeUrl: 'http://localhost:9650',
+    } as unknown as PrimaryNetworkCore;
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        // Reset mock implementation to default
+        mockWallet.getUtxos = vi.fn().mockResolvedValue([getValidUtxo(testInputAmount /* avax */)])
+    });
+
+    it('should create correct outputs and fees', async () => {
+        const receiverAddresses = [xAddressForTest, xAddressForTest3]
+
+        const importedOutput: ImportedOutput = {
+            addresses: receiverAddresses,
+            locktime: 1000,
+            threshold: 1,
+        }
+        const testOutputs: Output[] = []
+        const mockTxParams: ImportTxParams = {
+            importedOutput: importedOutput,
+            sourceChain: 'C'
+        };
+
+        const result = await newImportTx(mockPrimaryNetworkCoreClient, mockTxParams);
+        const outputs = result.getOutputs() // only imported output (no change outputs)
+
+        const fee = (await mockAvmRpc.getTxFee()).txFee
+
+        // imported output as the only change output
+        const testImportedOutputAmount = avaxToNanoAvax(testInputAmount) - fee
+        testOutputs.push({
+            amount: nanoAvaxToAvax(testImportedOutputAmount),
+            addresses: importedOutput.addresses,
+            locktime: importedOutput.locktime ?? 0,
+            threshold: importedOutput.threshold ?? 1,
+        })
+
+        // check outputs
+        checkOutputs(testOutputs, outputs)
+
+        // actual burned amount is same as fees
+        const allInputAmounts = result.tx.ins.reduce((acc, i) => acc + i.amount(), 0n)
+        const allOutputAmounts = outputs.reduce((acc, i) => acc + i.output.amount(), 0n)
+        expect(allInputAmounts - allOutputAmounts, 'expected and actual burned amount mismatch').toBe(fee)
+    });
+
+    it('should create correct import tx details', async () => {
+        const receiverAddresses = [xAddressForTest, xAddressForTest3]
+
+        const importedOutput: ImportedOutput = {
+            addresses: receiverAddresses,
+            locktime: 1000,
+            threshold: 1,
+        }
+        const mockTxParams: ImportTxParams = {
+            importedOutput: importedOutput,
+            sourceChain: 'C'
+        };
+        const result = await newImportTx(mockPrimaryNetworkCoreClient, mockTxParams);
+        expect(result.tx.sourceChain.value(), 'source chain mismatch').toBe(getChainIdFromAlias(mockTxParams.sourceChain, testContext.networkID))
+    });
+
+    it('should create correct tx hash', async () => {
+        const receiverAddresses = [xAddressForTest, xAddressForTest3]
+
+        const importedOutput: ImportedOutput = {
+            addresses: receiverAddresses,
+            locktime: 1000,
+            threshold: 1,
+        }
+        const mockTxParams: ImportTxParams = {
+            importedOutput: importedOutput,
+            sourceChain: 'C'
+        };
+        const result = await newImportTx(mockPrimaryNetworkCoreClient, mockTxParams);
+        await result.sign()
+        expect(result.getId(), 'transaction hash mismatch').toEqual('KkUc2CWQvxfrHn9qHDW4zUn9EuKNtQ3Xb2vjTYm3jJDgRoCBX')
+    });
+}); 

--- a/primary-network/src/transactions/x-chain/transactions/importTx.ts
+++ b/primary-network/src/transactions/x-chain/transactions/importTx.ts
@@ -1,0 +1,84 @@
+import { avm, utils, type avmSerial } from "@avalabs/avalanchejs";
+import { Transaction } from "../common/transaction";
+import { fetchCommonAvmTxParams, getChainIdFromAlias } from "../../common/utils";
+import type { CommonTxParams, NewTxParams } from "../../common/types";
+import type { P_CHAIN_ALIAS, C_CHAIN_ALIAS } from "../../common/consts";
+import type { PrimaryNetworkCore } from "../../../primaryNetworkCoreClient";
+
+export type ImportedOutput = {
+    /**
+     * The addresses to import the funds to. These are the
+     * addresses who can sign the consuming of this UTXO.
+     */
+    addresses: string[],
+    /**
+     * Optional. Timestamp in seconds after which this UTXO can be consumed.
+     */
+    locktime?: number,  
+    /**
+     * Optional. The number of signatures required out of the total `addresses`
+     * to spend the imported output.
+     */
+    threshold?: number,
+}
+
+/**
+ * Parameters for building an import transaction. There will be no change outputs,
+ * as the imported output will be the only output of the transaction.
+ */
+export type ImportTxParams = Omit<CommonTxParams, 'changeAddresses'> & {
+    /**
+     * The chain to import the funds from.
+     */
+    sourceChain: typeof P_CHAIN_ALIAS | typeof C_CHAIN_ALIAS;
+    /**
+     * Consolidated imported output from the atomic memory (source chain). Users
+     * cannot specify the amount, as it will be consolidation of all the UTXOs
+     * pending for import from the source chain.
+     */
+    importedOutput: ImportedOutput;
+}
+
+export class ImportTx extends Transaction {
+    override tx: avmSerial.ImportTx;
+
+    constructor(params: NewTxParams) {
+        super(params)
+        this.tx = params.unsignedTx.getTx() as avmSerial.ImportTx
+    }
+}
+
+export async function newImportTx(
+    primaryNetworkCoreClient: PrimaryNetworkCore,
+    txParams: ImportTxParams,
+): Promise<ImportTx> {
+    const context = await primaryNetworkCoreClient.initializeContextIfNot()
+    const { commonTxParams } = await fetchCommonAvmTxParams(
+        txParams,
+        context,
+        primaryNetworkCoreClient.avmRpc,
+        primaryNetworkCoreClient.wallet,
+        /* sourceChain = */ getChainIdFromAlias(txParams.sourceChain, context.networkID),
+    )
+
+    const unsignedTx = avm.newImportTx(
+        context,
+        getChainIdFromAlias(txParams.sourceChain, context.networkID),
+        commonTxParams.fromAddressesBytes,
+        commonTxParams.utxoSet,
+        txParams.importedOutput.addresses.map(utils.bech32ToBytes),
+        {
+            ...(commonTxParams.memo && { memo: commonTxParams.memo }),
+            ...(commonTxParams.minIssuanceTime && { minIssuanceTime: commonTxParams.minIssuanceTime }),
+            locktime: BigInt(txParams.importedOutput.locktime ?? 0),
+            threshold: txParams.importedOutput.threshold ?? 1,
+        },
+    );
+
+    return new ImportTx({
+        unsignedTx,
+        rpc: primaryNetworkCoreClient.avmRpc,
+        nodeUrl: primaryNetworkCoreClient.nodeUrl,
+        wallet: primaryNetworkCoreClient.wallet,
+    })
+}

--- a/primary-network/src/transactions/x-chain/transactions/importTx.ts
+++ b/primary-network/src/transactions/x-chain/transactions/importTx.ts
@@ -64,15 +64,15 @@ export async function newImportTx(
     const unsignedTx = avm.newImportTx(
         context,
         getChainIdFromAlias(txParams.sourceChain, context.networkID),
-        commonTxParams.fromAddressesBytes,
         commonTxParams.utxoSet,
         txParams.importedOutput.addresses.map(utils.bech32ToBytes),
+        commonTxParams.fromAddressesBytes,
         {
             ...(commonTxParams.memo && { memo: commonTxParams.memo }),
             ...(commonTxParams.minIssuanceTime && { minIssuanceTime: commonTxParams.minIssuanceTime }),
-            locktime: BigInt(txParams.importedOutput.locktime ?? 0),
-            threshold: txParams.importedOutput.threshold ?? 1,
         },
+        txParams.importedOutput.threshold ?? 1,
+        BigInt(txParams.importedOutput.locktime ?? 0),
     );
 
     return new ImportTx({

--- a/primary-network/src/wallet/wallet.ts
+++ b/primary-network/src/wallet/wallet.ts
@@ -52,7 +52,6 @@ export class Wallet {
         chainAlias: typeof P_CHAIN_ALIAS | typeof X_CHAIN_ALIAS | typeof C_CHAIN_ALIAS = P_CHAIN_ALIAS,
     ): Promise<Utxo[]> {
         let rpc: pvm.PVMApi | evm.EVMApi | avm.AVMApi;
-
         switch (chainAlias) {
             case C_CHAIN_ALIAS:
                 rpc = this.evmRpc;
@@ -61,7 +60,7 @@ export class Wallet {
                 rpc = this.avmRpc;
                 break;
             default:
-                rpc = this.pvmRpc; // P-Chain default
+                rpc = this.pvmRpc; 
         }
         const utxos = await rpc.getUTXOs({
             addresses: addresses ?? this.getBech32Addresses(chainAlias),


### PR DESCRIPTION
Added BaseTx, ExportTx, and ImportTx transaction type on x-chain and their respective test files. I used the implementation of these transactions on p-chain as a starting point because of Avm and Pvm similarities. Some more involved changes were needed because avm.newImportTx() has a difference function signature and params than pvm.newImportTx() from avalanchejs, for example.