### PR TITLE
feat(interchain): P-Chain message extraction helpers

### DIFF
--- a/interchain/package.json
+++ b/interchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avalanche-sdk/interchain",
-  "version": "0.0.1-alpha.1",
+  "version": "0.2.0-alpha.0",
   "description": "Interchain package for handling ICM/ICTT messages",
   "type": "module",
   "main": "./dist/index.js",

--- a/interchain/src/validator-manager/extractFromPChainTx.ts
+++ b/interchain/src/validator-manager/extractFromPChainTx.ts
@@ -1,0 +1,295 @@
+import { utils } from "@avalabs/avalanchejs";
+import type { Hex } from "viem";
+
+import { newConversionData } from "../warp/addressedCallMessages/conversionData.js";
+import { parseL1ValidatorWeightMessage } from "../warp/addressedCallMessages/l1ValidatorWeightMessage.js";
+import { parseRegisterL1ValidatorMessage } from "../warp/addressedCallMessages/registerL1ValidatorMessage.js";
+import { newSubnetToL1ConversionMessage } from "../warp/addressedCallMessages/subnetToL1ConversionMessage.js";
+import { parseAddressedCallPayload } from "../warp/addressedCallPayload.js";
+import { newWarpMessage } from "../warp/newWarpMessage.js";
+import { parseWarpUnsignedMessage } from "../warp/warpUnsignedMessage.js";
+
+/**
+ * Common arguments accepted by every `extract*FromPChainTx` helper.
+ *
+ * The SDK doesn't ship a P-Chain client. Instead, callers pass the JSON-RPC URL
+ * (and optionally a custom `fetch` for tests / Node < 18); the helper makes a
+ * single `platform.getTx` call and unwraps the warp message itself.
+ */
+export interface ExtractFromPChainTxArgs {
+    /** P-Chain transaction ID (base58check). */
+    txId: string;
+    /**
+     * P-Chain JSON-RPC URL, e.g.:
+     *   - `https://api.avax.network/ext/bc/P` (mainnet)
+     *   - `https://api.avax-test.network/ext/bc/P` (fuji)
+     *   - `http://localhost:9650/ext/bc/P` (local)
+     */
+    pChainRpcUrl: string;
+    /**
+     * Optional custom fetch implementation. Defaults to the global `fetch`.
+     * Tests pass an in-memory mock to avoid hitting the network.
+     */
+    fetchFn?: typeof fetch;
+}
+
+/**
+ * Minimal shape of `platform.getTx` `unsignedTx` we rely on. The helpers
+ * read `message` (warp message hex) plus tx-specific fields for the
+ * conversion variant; everything else is ignored.
+ */
+export interface PChainUnsignedTxShape {
+    message?: string;
+    subnetID?: string;
+    chainID?: string;
+    blockchainID?: string;
+    address?: string;
+    validators?: Array<PChainConversionTxValidator>;
+    [key: string]: unknown;
+}
+
+/**
+ * Validator entry as it appears under `unsignedTx.validators` in a
+ * `platform.getTx` response for a `ConvertSubnetToL1Tx`.
+ */
+export interface PChainConversionTxValidator {
+    nodeID: string;
+    weight: number;
+    balance: number;
+    signer: {
+        publicKey: string;
+        proofOfPossession: string;
+    };
+    remainingBalanceOwner: {
+        threshold: number;
+        addresses: string[];
+    };
+    deactivationOwner: {
+        threshold: number;
+        addresses: string[];
+    };
+}
+
+interface PlatformGetTxResponse {
+    result?: {
+        tx?: {
+            unsignedTx?: PChainUnsignedTxShape;
+        };
+    };
+    error?: {
+        message?: string;
+    };
+}
+
+/**
+ * Fetch a P-Chain tx by id and return its `unsignedTx`. Throws on RPC error or
+ * if the response shape is unexpected.
+ */
+async function fetchUnsignedPChainTx(args: ExtractFromPChainTxArgs): Promise<PChainUnsignedTxShape> {
+    const fetchImpl = args.fetchFn ?? fetch;
+    const response = await fetchImpl(args.pChainRpcUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            jsonrpc: "2.0",
+            method: "platform.getTx",
+            params: { txID: args.txId, encoding: "json" },
+            id: 1,
+        }),
+    });
+    if (!response.ok) {
+        throw new Error(`P-Chain RPC returned ${response.status}: ${response.statusText}`);
+    }
+    const data = (await response.json()) as PlatformGetTxResponse;
+    if (data.error?.message) {
+        throw new Error(`P-Chain RPC error: ${data.error.message}`);
+    }
+    const unsignedTx = data.result?.tx?.unsignedTx;
+    if (!unsignedTx) {
+        throw new Error("Invalid P-Chain transaction response — missing tx.unsignedTx");
+    }
+    return unsignedTx;
+}
+
+/**
+ * Unwrap `WarpUnsignedMessage → AddressedCall → innerPayload` from a tx that
+ * carries a warp message in `unsignedTx.message`.
+ */
+function unwrapInnerPayloadHex(unsignedTx: PChainUnsignedTxShape): Hex {
+    const message = unsignedTx.message;
+    if (typeof message !== "string" || message.length === 0) {
+        throw new Error("P-Chain transaction does not carry a warp message");
+    }
+    const warpUnsigned = parseWarpUnsignedMessage(message);
+    const addressedCallHex = `0x${warpUnsigned.payload.toString("hex")}`;
+    const addressedCall = parseAddressedCallPayload(addressedCallHex);
+    return `0x${addressedCall.payload.toString("hex")}` as Hex;
+}
+
+// ---------------------------------------------------------------------------
+// RegisterL1ValidatorMessage
+// ---------------------------------------------------------------------------
+
+export interface ExtractRegisterL1ValidatorMessageResult {
+    /** Inner `RegisterL1ValidatorMessage` payload hex (the AddressedCall's payload). */
+    messageHex: Hex;
+    /** 32-byte subnet ID, 0x-hex. */
+    subnetIdHex: Hex;
+    /** 20-byte node ID, 0x-hex. */
+    nodeIdHex: Hex;
+    /** 48-byte compressed BLS public key, 0x-hex. */
+    blsPublicKey: Hex;
+    /** Registration expiry as a Unix timestamp in seconds. */
+    expiry: bigint;
+    /** Initial validator weight. */
+    weight: bigint;
+}
+
+/**
+ * Fetch a `RegisterL1ValidatorTx` from P-Chain and extract the inner
+ * `RegisterL1ValidatorMessage` payload + decoded fields.
+ *
+ * The returned `messageHex` is the AddressedCall's inner payload —
+ * suitable for re-encoding or rebuilding the warp message for signing.
+ *
+ * @throws If the tx doesn't exist, is the wrong type, or doesn't carry a
+ *         warp message.
+ */
+export async function extractRegisterL1ValidatorMessageFromPChainTx(
+    args: ExtractFromPChainTxArgs,
+): Promise<ExtractRegisterL1ValidatorMessageResult> {
+    const unsignedTx = await fetchUnsignedPChainTx(args);
+    const innerPayloadHex = unwrapInnerPayloadHex(unsignedTx);
+    const parsed = parseRegisterL1ValidatorMessage(innerPayloadHex);
+    return {
+        messageHex: innerPayloadHex,
+        subnetIdHex: utils.bufferToHex(parsed.subnetId.toBytes()) as Hex,
+        nodeIdHex: utils.bufferToHex(parsed.nodeId.toBytes()) as Hex,
+        blsPublicKey: utils.bufferToHex(parsed.blsPublicKey.toBytes()) as Hex,
+        expiry: parsed.expiry.value(),
+        weight: parsed.weight.value(),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// L1ValidatorWeightMessage
+// ---------------------------------------------------------------------------
+
+export interface ExtractL1ValidatorWeightMessageResult {
+    /** Inner `L1ValidatorWeightMessage` payload hex. */
+    messageHex: Hex;
+    /** 32-byte validation ID, 0x-hex. */
+    validationIdHex: Hex;
+    /** Monotonically-increasing nonce of the weight update. */
+    nonce: bigint;
+    /** New weight assigned to the validator. */
+    weight: bigint;
+}
+
+/**
+ * Fetch a `SetL1ValidatorWeightTx` from P-Chain and extract the inner
+ * `L1ValidatorWeightMessage` payload + decoded fields.
+ */
+export async function extractL1ValidatorWeightMessageFromPChainTx(
+    args: ExtractFromPChainTxArgs,
+): Promise<ExtractL1ValidatorWeightMessageResult> {
+    const unsignedTx = await fetchUnsignedPChainTx(args);
+    const innerPayloadHex = unwrapInnerPayloadHex(unsignedTx);
+    const parsed = parseL1ValidatorWeightMessage(innerPayloadHex);
+    return {
+        messageHex: innerPayloadHex,
+        validationIdHex: utils.bufferToHex(parsed.validationId.toBytes()) as Hex,
+        nonce: parsed.nonce.value(),
+        weight: parsed.weight.value(),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// SubnetToL1ConversionData
+// ---------------------------------------------------------------------------
+
+export interface ExtractSubnetToL1ConversionDataArgs extends ExtractFromPChainTxArgs {
+    /**
+     * Avalanche network ID (1 mainnet, 5 fuji, 12345 local). Used as the
+     * `networkId` field of the rebuilt `WarpUnsignedMessage`; must match what
+     * the signature-aggregator will use, or signatures won't verify.
+     */
+    networkId: number;
+}
+
+export interface ExtractSubnetToL1ConversionDataResult {
+    /**
+     * Unsigned `SubnetToL1ConversionMessage` warp message hex — feed this to
+     * the signature aggregator together with `justificationHex` (below) as
+     * the `justification` parameter.
+     */
+    unsignedMessageHex: Hex;
+    /**
+     * ConversionData preimage hex. Aggregators need this as the
+     * `justification` so avalanchego's verifier can recompute the
+     * conversionID.
+     */
+    justificationHex: Hex;
+    /** Computed 32-byte conversion ID, 0x-hex. */
+    conversionIdHex: Hex;
+    /** Subnet ID (base58check). */
+    subnetId: string;
+    /** L1 blockchain ID (base58check). */
+    blockchainId: string;
+    /** ValidatorManager contract address (or proxy of one). */
+    managerAddress: Hex;
+    /** Validators as they appear in the tx (preserves the on-chain ordering). */
+    validators: PChainConversionTxValidator[];
+}
+
+/**
+ * Fetch a `ConvertSubnetToL1Tx` from P-Chain and produce everything needed
+ * to drive `initializeValidatorSet` end-to-end:
+ *
+ *   - the unsigned `SubnetToL1ConversionMessage` warp message (for signature
+ *     aggregation)
+ *   - the `ConversionData` preimage hex (= justification for the aggregator)
+ *   - the computed conversion ID
+ *   - the validators list as it appeared on-chain (caller may need to
+ *     resolve `signingSubnetId` separately via Glacier or another indexer)
+ *
+ * @throws If the tx isn't a ConvertSubnetToL1Tx or lacks the required fields.
+ */
+export async function extractSubnetToL1ConversionDataFromPChainTx(
+    args: ExtractSubnetToL1ConversionDataArgs,
+): Promise<ExtractSubnetToL1ConversionDataResult> {
+    const unsignedTx = await fetchUnsignedPChainTx(args);
+    const { subnetID, chainID, address, validators: rawValidators, blockchainID } = unsignedTx;
+    if (!subnetID || !chainID || !address || !rawValidators || !blockchainID) {
+        throw new Error(
+            "P-Chain transaction is missing required ConvertSubnetToL1Tx fields " +
+                "(subnetID / chainID / address / validators / blockchainID)",
+        );
+    }
+
+    // newConversionData sorts validators by raw nodeId bytes internally for
+    // canonical conversionID hashing.
+    const sdkValidators = rawValidators.map((v) => ({
+        nodeId: v.nodeID,
+        blsPublicKey: v.signer.publicKey,
+        weight: BigInt(v.weight),
+    }));
+
+    const conversionData = newConversionData(subnetID, chainID, address, sdkValidators);
+    const conversionIdHex = conversionData.getConversionId() as Hex;
+    const conversionIdCB58 = utils.base58check.encode(utils.hexToBuffer(conversionIdHex));
+
+    // Build the SubnetToL1ConversionMessage and wrap it in a WarpUnsignedMessage.
+    const innerMsg = newSubnetToL1ConversionMessage(conversionIdCB58);
+    const unsigned = newWarpMessage(args.networkId, blockchainID, "", innerMsg.toHex());
+
+    return {
+        unsignedMessageHex: unsigned.toHex() as Hex,
+        justificationHex: conversionData.toHex() as Hex,
+        conversionIdHex,
+        subnetId: subnetID,
+        blockchainId: chainID,
+        managerAddress: (address.startsWith("0x") ? address : `0x${address}`) as Hex,
+        validators: rawValidators,
+    };
+}

--- a/interchain/src/validator-manager/index.ts
+++ b/interchain/src/validator-manager/index.ts
@@ -79,6 +79,19 @@ export {
 export { linkBytecode, listUnlinkedLibraries } from "./linkBytecode.js";
 
 export {
+    extractRegisterL1ValidatorMessageFromPChainTx,
+    extractL1ValidatorWeightMessageFromPChainTx,
+    extractSubnetToL1ConversionDataFromPChainTx,
+    type ExtractFromPChainTxArgs,
+    type ExtractRegisterL1ValidatorMessageResult,
+    type ExtractL1ValidatorWeightMessageResult,
+    type ExtractSubnetToL1ConversionDataArgs,
+    type ExtractSubnetToL1ConversionDataResult,
+    type PChainConversionTxValidator,
+    type PChainUnsignedTxShape,
+} from "./extractFromPChainTx.js";
+
+export {
     PoAManagerAbi,
     PoAManagerBytecode,
 } from "./artifacts/PoAManager.js";

--- a/interchain/test/extract-from-pchain-tx.test.ts
+++ b/interchain/test/extract-from-pchain-tx.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "bun:test";
+import { utils } from "@avalabs/avalanchejs";
+
+import {
+    extractL1ValidatorWeightMessageFromPChainTx,
+    extractRegisterL1ValidatorMessageFromPChainTx,
+    extractSubnetToL1ConversionDataFromPChainTx,
+} from "../src/validator-manager/extractFromPChainTx.ts";
+import { P_CHAIN_BLOCKCHAIN_ID } from "../src/warp/constants.ts";
+import { newL1ValidatorWeightMessage } from "../src/warp/addressedCallMessages/l1ValidatorWeightMessage.ts";
+import { newRegisterL1ValidatorMessage } from "../src/warp/addressedCallMessages/registerL1ValidatorMessage.ts";
+import { newWarpMessage } from "../src/warp/newWarpMessage.ts";
+
+const SUBNET_ID_B58 = "BDfW7SyeCh9Puiw1EBWrx653xQnzGtUrV9k83rAodqiCMViXZ";
+const VALIDATION_ID_B58 = "11111111111111111111111111111111LpoYY"; // 32 zero bytes
+const CHAIN_ID_B58 = "2oYMBNV4eNHyqk2fjjV5nVQLDbtmNJzq5s3qs3Lo6ftnC6FByM";
+const NODE_ID = "NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg";
+const BLS_PUB =
+    "0x933320c54cdb8159038d9a90df5601a80f206a08c4a8a81c7f0f139bb64d7cfb43bbfd88e47e970e84114649c616ab85";
+// The 20-byte EWOQ hash re-encoded as a P-local bech32 string.
+const EWOQ_P_BYTES = new Uint8Array([
+    0x3c, 0xb7, 0xd3, 0x84, 0x2e, 0x8c, 0xee, 0x6a, 0x0e, 0xbd,
+    0x09, 0xf1, 0xfe, 0x88, 0x4f, 0x68, 0x61, 0xe1, 0xb2, 0x9c,
+]);
+const EWOQ_P_LOCAL = `P-${utils.formatBech32("local", EWOQ_P_BYTES)}`;
+const P_CHAIN_OWNER = {
+    threshold: 1,
+    addresses: [EWOQ_P_LOCAL],
+};
+
+const FUJI_NETWORK_ID = 5;
+const FAKE_RPC_URL = "https://test.invalid/ext/bc/P";
+const FAKE_TX_ID = "fake-tx-id-only-used-as-passthrough";
+
+/**
+ * Build a Fetch-compatible mock that returns the given `unsignedTx` shape
+ * as the result of a single `platform.getTx` call.
+ */
+function mockGetTx(unsignedTx: Record<string, unknown>): typeof fetch {
+    return (async () => {
+        return new Response(
+            JSON.stringify({
+                jsonrpc: "2.0",
+                id: 1,
+                result: { tx: { unsignedTx } },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+    }) as unknown as typeof fetch;
+}
+
+describe("extractRegisterL1ValidatorMessageFromPChainTx", () => {
+    test("decodes round-tripped fields", async () => {
+        const expiry = 1_700_000_000n;
+        const weight = 50n;
+        const inner = newRegisterL1ValidatorMessage(
+            SUBNET_ID_B58,
+            NODE_ID,
+            BLS_PUB,
+            expiry,
+            P_CHAIN_OWNER,
+            P_CHAIN_OWNER,
+            weight,
+        );
+        // P-Chain wraps the payload with system source on its own blockchain id.
+        const unsignedWarp = newWarpMessage(FUJI_NETWORK_ID, P_CHAIN_BLOCKCHAIN_ID, "", inner.toHex());
+
+        const result = await extractRegisterL1ValidatorMessageFromPChainTx({
+            txId: FAKE_TX_ID,
+            pChainRpcUrl: FAKE_RPC_URL,
+            fetchFn: mockGetTx({ message: unsignedWarp.toHex() }),
+        });
+
+        expect(result.expiry).toBe(expiry);
+        expect(result.weight).toBe(weight);
+        expect(result.blsPublicKey).toBe(BLS_PUB as `0x${string}`);
+        expect(result.subnetIdHex).toBe(
+            utils.bufferToHex(utils.base58check.decode(SUBNET_ID_B58)) as `0x${string}`,
+        );
+        // nodeId should be the 20-byte hash from `NodeID-...`
+        expect(result.nodeIdHex.length).toBe(2 + 20 * 2);
+        // The inner messageHex round-trips through `newRegisterL1ValidatorMessage(...).toHex()`.
+        expect(result.messageHex).toBe(inner.toHex() as `0x${string}`);
+    });
+
+    test("throws when the tx has no warp message", async () => {
+        await expect(
+            extractRegisterL1ValidatorMessageFromPChainTx({
+                txId: FAKE_TX_ID,
+                pChainRpcUrl: FAKE_RPC_URL,
+                fetchFn: mockGetTx({ subnetID: SUBNET_ID_B58 /* missing `message` */ }),
+            }),
+        ).rejects.toThrow(/does not carry a warp message/);
+    });
+
+    test("throws when the RPC returns an error body", async () => {
+        const errFetch = (async () =>
+            new Response(
+                JSON.stringify({ jsonrpc: "2.0", id: 1, error: { message: "tx not found" } }),
+                { status: 200, headers: { "Content-Type": "application/json" } },
+            )) as unknown as typeof fetch;
+        await expect(
+            extractRegisterL1ValidatorMessageFromPChainTx({
+                txId: FAKE_TX_ID,
+                pChainRpcUrl: FAKE_RPC_URL,
+                fetchFn: errFetch,
+            }),
+        ).rejects.toThrow(/P-Chain RPC error: tx not found/);
+    });
+});
+
+describe("extractL1ValidatorWeightMessageFromPChainTx", () => {
+    test("decodes round-tripped fields", async () => {
+        const nonce = 42n;
+        const weight = 100n;
+        const inner = newL1ValidatorWeightMessage(VALIDATION_ID_B58, nonce, weight);
+        const unsignedWarp = newWarpMessage(FUJI_NETWORK_ID, P_CHAIN_BLOCKCHAIN_ID, "", inner.toHex());
+
+        const result = await extractL1ValidatorWeightMessageFromPChainTx({
+            txId: FAKE_TX_ID,
+            pChainRpcUrl: FAKE_RPC_URL,
+            fetchFn: mockGetTx({ message: unsignedWarp.toHex() }),
+        });
+
+        expect(result.nonce).toBe(nonce);
+        expect(result.weight).toBe(weight);
+        expect(result.validationIdHex).toBe(
+            utils.bufferToHex(utils.base58check.decode(VALIDATION_ID_B58)) as `0x${string}`,
+        );
+        expect(result.messageHex).toBe(inner.toHex() as `0x${string}`);
+    });
+});
+
+describe("extractSubnetToL1ConversionDataFromPChainTx", () => {
+    test("builds the unsigned warp message and justification from tx fields", async () => {
+        const managerAddress = "0xfacade0000000000000000000000000000000000" as `0x${string}`;
+        const validators = [
+            {
+                nodeID: NODE_ID,
+                weight: 100,
+                balance: 1000,
+                signer: { publicKey: BLS_PUB, proofOfPossession: BLS_PUB },
+                remainingBalanceOwner: { threshold: 1, addresses: [EWOQ_P_LOCAL] },
+                deactivationOwner: { threshold: 1, addresses: [EWOQ_P_LOCAL] },
+            },
+        ];
+
+        const result = await extractSubnetToL1ConversionDataFromPChainTx({
+            txId: FAKE_TX_ID,
+            pChainRpcUrl: FAKE_RPC_URL,
+            networkId: FUJI_NETWORK_ID,
+            fetchFn: mockGetTx({
+                subnetID: SUBNET_ID_B58,
+                chainID: CHAIN_ID_B58,
+                address: managerAddress,
+                blockchainID: CHAIN_ID_B58,
+                validators,
+            }),
+        });
+
+        expect(result.subnetId).toBe(SUBNET_ID_B58);
+        expect(result.blockchainId).toBe(CHAIN_ID_B58);
+        expect(result.managerAddress).toBe(managerAddress);
+        expect(result.validators).toEqual(validators);
+        // conversionIdHex is a 32-byte 0x-hex string.
+        expect(result.conversionIdHex.length).toBe(2 + 32 * 2);
+        // unsignedMessageHex and justificationHex are non-empty 0x-hex strings.
+        expect(result.unsignedMessageHex.startsWith("0x")).toBe(true);
+        expect(result.justificationHex.startsWith("0x")).toBe(true);
+        expect(result.unsignedMessageHex.length).toBeGreaterThan(2);
+        expect(result.justificationHex.length).toBeGreaterThan(2);
+    });
+
+    test("throws on missing required fields", async () => {
+        await expect(
+            extractSubnetToL1ConversionDataFromPChainTx({
+                txId: FAKE_TX_ID,
+                pChainRpcUrl: FAKE_RPC_URL,
+                networkId: FUJI_NETWORK_ID,
+                fetchFn: mockGetTx({ subnetID: SUBNET_ID_B58 /* missing chainID etc. */ }),
+            }),
+        ).rejects.toThrow(/missing required ConvertSubnetToL1Tx fields/);
+    });
+});


### PR DESCRIPTION
## Summary

Adds three orchestrator-level helpers under `validator-manager/` that fetch a P-Chain tx and return the inner warp message payload + decoded fields — no wallet client needed; caller passes the P-Chain JSON-RPC URL.

| Helper | Returns | Used downstream by |
|---|---|---|
| `extractRegisterL1ValidatorMessageFromPChainTx` | inner `RegisterL1ValidatorMessage` payload + `(subnetIdHex, nodeIdHex, blsPublicKey, expiry, weight)` | `completeValidatorRegistration` (deriving the ack message + justification) |
| `extractL1ValidatorWeightMessageFromPChainTx` | inner `L1ValidatorWeightMessage` payload + `(validationIdHex, nonce, weight)` | `completeValidatorWeightUpdate` |
| `extractSubnetToL1ConversionDataFromPChainTx` | unsigned `SubnetToL1ConversionMessage` + `ConversionData` preimage (justification) + computed `conversionIdHex` + validators in tx-order | `initializeValidatorSet` (driving signature aggregation) |

All three accept an optional `fetchFn` override so tests / Node-without-global-fetch work without hitting the network. `signingSubnetId` stays a caller concern (typically resolved via Glacier or another indexer) — kept out of the SDK to avoid pulling in a Glacier dep.

## Why

Surfaced from migrating [builders-hub](https://github.com/ava-labs/builders-hub) off three hand-written `fetch*Data` files that re-implemented this pipeline locally. Each was ~70 lines of `platform.getTx` + warp-unwrap + parser glue. The SDK ships the parsers; the fetch+unwrap+expose pipeline belongs next to them.

## Test plan

- [x] `bun test test/extract-from-pchain-tx.test.ts` — 6 new tests, all passing
- [x] `bun test test/` — 35 tests across 4 files, all passing (no regressions)
- [x] `npm run typecheck` clean
- [ ] Downstream: bump `@avalanche-sdk/interchain` in builders-hub PR #4187 and replace `fetchConversionData` / `fetchRegisterL1ValidatorData` / `fetchL1ValidatorWeightData` with these helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)