### PR TITLE
fix(interchain): SubnetToL1Conversion justification is the subnetID, not the preimage

### DIFF
--- a/interchain/src/validator-manager/extractFromPChainTx.ts
+++ b/interchain/src/validator-manager/extractFromPChainTx.ts
@@ -225,11 +225,25 @@ export interface ExtractSubnetToL1ConversionDataResult {
      */
     unsignedMessageHex: Hex;
     /**
-     * ConversionData preimage hex. Aggregators need this as the
-     * `justification` so avalanchego's verifier can recompute the
-     * conversionID.
+     * Justification bytes for the signature aggregator, hex-encoded.
+     *
+     * For `SubnetToL1ConversionMessage` this is the **32-byte subnetID**
+     * (NOT the ConversionData preimage). AvalancheGo's verifier looks up
+     * the conversion locally by subnetID, hashes its own copy of the
+     * ConversionData, and checks against the conversionID in the warp
+     * message. Sending the full preimage produces
+     * `"invalid hash length: expected 32 bytes but got 174"` from the
+     * validator's `SignatureRequestVerifier` (avalanchego ≥ 1.14.x).
      */
     justificationHex: Hex;
+    /**
+     * The raw `ConversionData` preimage hex. Not the aggregator's
+     * justification — see {@link justificationHex} — but useful for
+     * callers that want to sanity-check the conversionID
+     * (`sha256(conversionDataHex) === conversionIdHex`) or pin the
+     * canonical layout for tests.
+     */
+    conversionDataHex: Hex;
     /** Computed 32-byte conversion ID, 0x-hex. */
     conversionIdHex: Hex;
     /** Subnet ID (base58check). */
@@ -283,9 +297,16 @@ export async function extractSubnetToL1ConversionDataFromPChainTx(
     const innerMsg = newSubnetToL1ConversionMessage(conversionIdCB58);
     const unsigned = newWarpMessage(args.networkId, blockchainID, "", innerMsg.toHex());
 
+    // Justification for the aggregator is the 32-byte subnetID (not the
+    // ConversionData preimage). See ExtractSubnetToL1ConversionDataResult
+    // doc-comment for why.
+    const subnetIdBytes = utils.base58check.decode(subnetID);
+    const justificationHex = utils.bufferToHex(subnetIdBytes) as Hex;
+
     return {
         unsignedMessageHex: unsigned.toHex() as Hex,
-        justificationHex: conversionData.toHex() as Hex,
+        justificationHex,
+        conversionDataHex: conversionData.toHex() as Hex,
         conversionIdHex,
         subnetId: subnetID,
         blockchainId: chainID,

--- a/interchain/test/extract-from-pchain-tx.test.ts
+++ b/interchain/test/extract-from-pchain-tx.test.ts
@@ -164,11 +164,21 @@ describe("extractSubnetToL1ConversionDataFromPChainTx", () => {
         expect(result.validators).toEqual(validators);
         // conversionIdHex is a 32-byte 0x-hex string.
         expect(result.conversionIdHex.length).toBe(2 + 32 * 2);
-        // unsignedMessageHex and justificationHex are non-empty 0x-hex strings.
+        // Aggregator justification MUST be the 32-byte subnetID (NOT the
+        // ConversionData preimage). avalanchego's signature-request verifier
+        // looks up the conversion locally by subnetID; handing it the full
+        // preimage yields "invalid hash length: expected 32 bytes but got 174"
+        // and the validator silently refuses to sign.
+        expect(result.justificationHex.length).toBe(2 + 32 * 2);
+        expect(result.justificationHex).toBe(
+            utils.bufferToHex(utils.base58check.decode(SUBNET_ID_B58)) as `0x${string}`,
+        );
+        // conversionDataHex is the full preimage (variable length, depends on
+        // the validator set). Sanity: sha256(conversionDataHex) === conversionIdHex.
+        expect(result.conversionDataHex.startsWith("0x")).toBe(true);
+        expect(result.conversionDataHex.length).toBeGreaterThan(2 + 32 * 2);
         expect(result.unsignedMessageHex.startsWith("0x")).toBe(true);
-        expect(result.justificationHex.startsWith("0x")).toBe(true);
         expect(result.unsignedMessageHex.length).toBeGreaterThan(2);
-        expect(result.justificationHex.length).toBeGreaterThan(2);
     });
 
     test("throws on missing required fields", async () => {


### PR DESCRIPTION
## Summary

`extractSubnetToL1ConversionDataFromPChainTx` was returning `justificationHex` as the 174-byte `ConversionData` preimage. AvalancheGo's `SignatureRequestVerifier` for `SubnetToL1ConversionMessage` expects the **32-byte subnetID** — it uses that to look up its own local copy of the conversion data, hashes it, and compares to the conversionID in the unsigned message. Handing it the full preimage surfaces:

```
"failed to parse justification: invalid hash length: expected 32 bytes but got 174"
```

via `AppError` on the AppRequest channel. The signature-aggregator (both [icm-services](https://github.com/ava-labs/icm-services) and Glacier's hosted aggregator) bubbles this up as `"failed to collect a threshold of signatures"` / HTTP 500 with no further detail, so the bug manifests as an infinite hang in any caller — including builders-hub's `Initialize Validator Set` wizard step.

## Fix

`justificationHex` is now the 32-byte subnetID. The full ConversionData preimage stays exposed as a new `conversionDataHex` field for callers that need it (e.g. to sanity-check `sha256(conversionDataHex) === conversionIdHex` or pin canonical layout in tests).

## Verified

End-to-end against two aggregators:

| Aggregator | Status | Latency |
|---|---|---|
| Local icm-services binary (built from latest main, configured with `manually-tracked-peers` for the L1 validator) | HTTP 200 | 866ms |
| Glacier `data-api.avax.network/v1/signatureAggregator/fuji/aggregateSignatures` | HTTP 201 | 382ms |

Both return a valid signed warp message that the on-chain warp precompile accepts.

## Test changes

`extract-from-pchain-tx.test.ts` now asserts the exact shape: `justificationHex.length === 2 + 32*2` and `=== bufferToHex(base58check.decode(subnetID))`. Also covers the new `conversionDataHex` field. All 35 tests pass.

## Downstream

- Published as [`@avalanche-sdk/interchain@0.2.0-alpha.2`](https://www.npmjs.com/package/@avalanche-sdk/interchain/v/0.2.0-alpha.2) via the existing tag-trigger workflow
- builders-hub PR [ava-labs/builders-hub#4187](https://github.com/ava-labs/builders-hub/pull/4187) bumped to `^0.2.0-alpha.2` — no call-site changes needed (just consumes `data.justificationHex` whose value is now correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)