### PR TITLE
fix(interchain): loosen MinimalWalletClient.account.address to string so viem WalletClient is cast-free

### DIFF
--- a/interchain/src/validator-manager/clientTypes.ts
+++ b/interchain/src/validator-manager/clientTypes.ts
@@ -39,7 +39,14 @@ export interface MinimalWalletClient {
     writeContract: (params: any) => Promise<Hex>;
     deployContract: (params: any) => Promise<Hex>;
     readonly chain?: { id?: number } | null | undefined;
-    readonly account?: { address: `0x${string}` } | null | undefined;
+    // `address` typed as plain `string` (not `0x${string}`) so viem's
+    // `WalletClient` is directly assignable without casts. viem types
+    // `Account.address` as `string`; tightening it to a template literal
+    // here would force consumers into `as never`/`as unknown` at the call
+    // site. The orchestrators always feed this value into viem's
+    // `writeContract`/`deployContract`, which re-asserts the `0x...` shape
+    // at runtime, so we don't lose any safety by loosening the static type.
+    readonly account?: { address: string } | null | undefined;
 }
 
 /**

--- a/interchain/src/validator-manager/evmHelpers.ts
+++ b/interchain/src/validator-manager/evmHelpers.ts
@@ -68,10 +68,11 @@ export async function assertSuccessOrReplay(
         /**
          * Account-like shape — viem's `call({ account })` accepts either an
          * `Account`, a bare address, or anything with `.address`. Loosened
-         * so callers passing a `MinimalWalletClient.account` don't need to
-         * coerce to viem's full `Account` identity.
+         * to plain `string` for the `.address` shape so callers passing a
+         * `MinimalWalletClient.account` (whose `address` is typed as plain
+         * `string` to match viem's `Account.address`) don't need any cast.
          */
-        account?: { address: Address } | Account | Address;
+        account?: { address: string } | Account | Address;
         opName?: string;
     },
 ): Promise<void> {


### PR DESCRIPTION
## Summary

`MinimalWalletClient.account.address` was typed `\`0x\${string}\``. viem's `WalletClient.account` is typed `Account | undefined` where `Account = JsonRpcAccount | LocalAccount | SmartAccount` — and under the cross-instance scenario the SDK docstring warns about (one viem in the SDK's own `node_modules`, another in the consumer's), the consumer's instantiated `Address` type collapses to plain `string`. The template-literal constraint never matched, so every consumer was forced into `as never` / `as unknown as MinimalWalletClient` casts at the call boundary — exactly the friction the structural type was supposed to remove.

Loosening to `string` lets any viem `WalletClient` be structurally assignable cast-free. No runtime safety lost: the orchestrators feed the value through to viem's `writeContract` / `deployContract` / `call` which re-assert the `0x...` shape at runtime.

## Changes

- `MinimalWalletClient.account.address: \`0x\${string}\`` → `string`
- `assertSuccessOrReplay`'s `account?` arg type loosened similarly (`{ address: string } | Account | Address`) so internal callers passing `wc.account ?? null` still typecheck
- Doc-comments updated explaining the loosening
- 35 SDK tests still pass

## Verification

Stripped every `as never` from builders-hub's wizard call sites and ran `yarn tsc --noEmit` clean. Builders-hub PR [#4187](https://github.com/ava-labs/builders-hub/pull/4187) bumped to `^0.2.0-alpha.3` and ships the cast-free codepath.

## Downstream

- Published as [`@avalanche-sdk/interchain@0.2.0-alpha.3`](https://www.npmjs.com/package/@avalanche-sdk/interchain/v/0.2.0-alpha.3) via the existing tag-trigger workflow
- Builders-hub PR #4187 already consuming it

🤖 Generated with [Claude Code](https://claude.com/claude-code)