### PR TITLE
fix(ci): pin npm@11 in client publish workflow

### DIFF
--- a/.github/workflows/client_sdk_publish.yaml
+++ b/.github/workflows/client_sdk_publish.yaml
@@ -60,7 +60,7 @@ jobs:
           npm run build:all --if-present
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Check if version exists
         id: check_version


### PR DESCRIPTION
The `Update npm` step runs `npm install -g npm@latest`; npm@12 now requires Node >=22 while this workflow pins Node 20, so publishing fails with EBADENGINE (see run 29611680665, blocking the client/v0.1.2 release). Pin npm@11, which supports Node 20 and satisfies npm trusted publishing (>=11.5.1).